### PR TITLE
feat(endpoint): adds POST /movies endpoint, plugins for movie controller, validator, and the unit tests for each plugins

### DIFF
--- a/db/migrations/.eslintrc
+++ b/db/migrations/.eslintrc
@@ -1,4 +1,3 @@
 {
   "extends": "lob/migrations"
 }
-

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const Movie = require('../../../models/movie');
+
+exports.create = (payload) => {
+  return new Movie().save(payload)
+  .then((movie) => {
+    return new Movie({ id: movie.id }).fetch();
+  });
+};

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const Controller     = require('./controller');
+const MovieValidator = require('../../../validators/movie');
+
+exports.register = (server, options, next) => {
+
+  server.route([{
+    method: 'POST',
+    path: '/movies',
+    config: {
+      handler: (request, reply) => {
+        reply(Controller.create(request.payload));
+      },
+      validate: {
+        payload: MovieValidator
+      }
+    }
+  }]);
+
+  next();
+
+};
+
+exports.register.attributes = {
+  name: 'movies'
+};
+

--- a/lib/server.js
+++ b/lib/server.js
@@ -22,6 +22,7 @@ server.register([
   },
   require('./plugins/features/movies')
 ], (err) => {
+  /* istanbul ignore if */
   if (err) {
     throw err;
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -14,4 +14,17 @@ const server = new Hapi.Server({
 
 server.connection({ port: Config.PORT });
 
+server.register([
+  require('hapi-bookshelf-serializer'),
+  {
+    register: require('hapi-format-error'),
+    options: { joiStatusCode: 422 }
+  },
+  require('./plugins/features/movies')
+], (err) => {
+  if (err) {
+    throw err;
+  }
+});
+
 module.exports = server;

--- a/lib/validators/movie.js
+++ b/lib/validators/movie.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const Joi = require('joi');
+
+module.exports = Joi.object().keys({
+  title: Joi.string().min(1).max(255).required(),
+  release_year: Joi.number().integer().min(1878).max(9999).optional()
+});
+

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "bookshelf": "^0.12.1",
     "hapi": "14.2.0",
     "hapi-bookshelf-serializer": "^2.1.0",
+    "hapi-format-error": "^1.1.0",
+    "joi": "12",
     "knex": "^0.14.4",
     "pg": "^7.4.1"
   },

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const Controller = require('../../../../lib/plugins/features/movies/controller');
+const Movie      = require('../../../../lib/models/movie');
+
+describe('movie controller', () => {
+
+  describe('create', () => {
+
+    it('creates a movie', () => {
+      const payload = { title: 'WALL-E' };
+
+      return Controller.create(payload)
+      .then((movie) => {
+        expect(movie.get('title')).to.eql(payload.title);
+
+        return new Movie({ id: movie.id }).fetch();
+      })
+      .then((movie) => {
+        expect(movie.get('title')).to.eql(payload.title);
+      });
+    });
+
+  });
+
+});

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const Movies = require('../../../../lib/server');
+
+describe('movies integration', () => {
+
+  describe('create', () => {
+
+    it('creates a movie', () => {
+      return Movies.inject({
+        url: '/movies',
+        method: 'POST',
+        payload: { title: 'Volver' }
+      })
+      .then((response) => {
+        expect(response.statusCode).to.eql(200);
+        expect(response.result.object).to.eql('movie');
+      });
+    });
+
+  });
+
+});

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -13,18 +13,14 @@ describe('movie validator', () => {
       const result = Joi.validate(payload, MovieValidator);
 
       expect(result.error.details[0].path[0]).to.eql('title');
-
       expect(result.error.details[0].type).to.eql('any.required');
     });
 
     it('is less than 255 characters', () => {
-      const payload = {
-        title: 'a'.repeat(260)
-      };
+      const payload = { title: 'a'.repeat(260) };
       const result = Joi.validate(payload, MovieValidator);
 
       expect(result.error.details[0].path[0]).to.eql('title');
-
       expect(result.error.details[0].type).to.eql('string.max');
     });
 
@@ -40,7 +36,6 @@ describe('movie validator', () => {
       const result = Joi.validate(payload, MovieValidator);
 
       expect(result.error.details[0].path[0]).to.eql('release_year');
-
       expect(result.error.details[0].type).to.eql('number.min');
 
     });
@@ -53,11 +48,9 @@ describe('movie validator', () => {
       const result = Joi.validate(payload, MovieValidator);
 
       expect(result.error.details[0].path[0]).to.eql('release_year');
-
       expect(result.error.details[0].type).to.eql('number.max');
     });
 
   });
 
 });
-

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const Joi = require('joi');
+
+const MovieValidator = require('../../lib/validators/movie');
+
+describe('movie validator', () => {
+
+  describe('title', () => {
+
+    it('is required', () => {
+      const payload = {};
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('title');
+
+      expect(result.error.details[0].type).to.eql('any.required');
+    });
+
+    it('is less than 255 characters', () => {
+      const payload = {
+        title: 'a'.repeat(260)
+      };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('title');
+
+      expect(result.error.details[0].type).to.eql('string.max');
+    });
+
+  });
+
+  describe('release_year', () => {
+
+    it('is after 1878', () => {
+      const payload = {
+        title: 'foo',
+        release_year: 1800
+      };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('release_year');
+
+      expect(result.error.details[0].type).to.eql('number.min');
+
+    });
+
+    it('is limited to 4 digits', () => {
+      const payload = {
+        title: 'foo',
+        release_year: 12345
+      };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('release_year');
+
+      expect(result.error.details[0].type).to.eql('number.max');
+    });
+
+  });
+
+});
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -1249,6 +1249,10 @@ hapi-bookshelf-serializer@^2.1.0:
     bluebird "^2.9.34"
     boom "^2.8.0"
 
+hapi-format-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/hapi-format-error/-/hapi-format-error-1.1.0.tgz#28d97f82b40f1b1d1b62b0215eab1cdfe983bbde"
+
 hapi@14.2.0:
   version "14.2.0"
   resolved "https://registry.yarnpkg.com/hapi/-/hapi-14.2.0.tgz#e4fe2fc182598a0f81e87b41b6be0fbd31c75409"
@@ -1645,6 +1649,12 @@ isemail@2.x.x:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isemail/-/isemail-2.2.1.tgz#0353d3d9a62951080c262c2aa0a42b8ea8e9e2a6"
 
+isemail@3.x.x:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/isemail/-/isemail-3.1.1.tgz#e8450fe78ff1b48347db599122adcd0668bd92b5"
+  dependencies:
+    punycode "2.x.x"
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -1700,6 +1710,14 @@ joi@10.x.x:
     hoek "4.x.x"
     isemail "2.x.x"
     items "2.x.x"
+    topo "2.x.x"
+
+joi@12:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-12.0.0.tgz#46f55e68f4d9628f01bbb695902c8b307ad8d33a"
+  dependencies:
+    hoek "4.x.x"
+    isemail "3.x.x"
     topo "2.x.x"
 
 joi@9.x.x:
@@ -2597,6 +2615,10 @@ pstree.remy@^1.1.0:
   resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.0.tgz#f2af27265bd3e5b32bbfcc10e80bac55ba78688b"
   dependencies:
     ps-tree "^1.1.0"
+
+punycode@2.x.x:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
 
 punycode@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
**What:**
- Adds the POST /movies endpoint to the server
- Adds the following plugins:
  - movie controller
  - movie validator
- Adds unit tests for the endpoint, controller, and validator

**Why:**
API needs an endpoint to receive movies. The plugin architecture is in accordance to Lob's engineering practices. Controller handles the POST request to insert new movies into the database. Validator ensures that the incoming payload has the necessary resources/parameters in the JSON and also in a proper format to be handled properly.

**Context:**
The previous PR created the database, model, and connection
The next PR will be on the integration tests
The next next PR will be on the zero downtime schema changes

**Details:**
New technologies implemented in this PR:
- hapi-format-error: used as a way to nicely present Boom's error messages
- Joi: used as a JSON object schema validator