### PR TITLE
feat(migration_1/4): adds column "name" and makes "title" column nullable

### DIFF
--- a/db/migrations/20180302131905_add_name_to_movies.js
+++ b/db/migrations/20180302131905_add_name_to_movies.js
@@ -1,0 +1,19 @@
+'use strict';
+
+exports.up = (Knex, Promise) => {
+  return Knex.schema.table('movies', (table) => {
+    table.text('name');
+  })
+  .then(() => {
+    return Knex.raw('ALTER TABLE movies ALTER COLUMN title DROP NOT NULL');
+  });
+};
+
+exports.down = (Knex, Promise) => {
+  return Knex.schema.table('movies', (table) => {
+    table.dropColumn('name');
+  })
+  .then(() => {
+    return Knex.raw('ALTER TABLE movies ALTER COLUMN title SET NOT NULL');
+  });
+};


### PR DESCRIPTION
**What:**
- Adds a nullable column "name"
- Removes the not-null constraint on the column "title"

**Why:**
Prepares the database to handle writes to both old and new columns. Ultimate goal is for "name" column to replace "title" column, achieving a final result of renaming a column.

**Context:**
Step 1 of 4 migration steps for renaming a database column from "title" to "name".
Next PR: Step 2 of 4, updating the application code to save values to both "title" and "name" column and backfilling the null values from "title" to "name".