### PR TITLE
feat(migration_3/4): backfill all `null` values of new column

### DIFF
--- a/db/migrations/20180302174739_backfill_movies_name.js
+++ b/db/migrations/20180302174739_backfill_movies_name.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.up = (Knex, Promise) => {
+  return Knex.raw('UPDATE movies SET name = title');
+};
+
+exports.down = (Knex, Promise) => {
+  return Promise.resolve();
+};

--- a/db/migrations/20180302174739_backfill_movies_name.js
+++ b/db/migrations/20180302174739_backfill_movies_name.js
@@ -1,7 +1,7 @@
 'use strict';
 
 exports.up = (Knex, Promise) => {
-  return Knex.raw('UPDATE movies SET name = title');
+  return Knex.raw('UPDATE movies SET name = title WHERE name IS NULL');
 };
 
 exports.down = (Knex, Promise) => {


### PR DESCRIPTION
**What:**
- Adds migration script that backfills `null` values of `name` column

**Why:**
To rename "title" column to "name"

**Context:**
Previous PR: Step 2 of 4 - server must write to both new and old columns in preparation for backfilling the new column
Next PR: Step 3b of 4 - update application code to stop adding into `title` column, but maintain the same API parameters

**Details:**
- Must migrate both sfmovies_development and sfmovies_test databases to pass unit tests and actual live server testing