### PR TITLE
feat(migration_4/4): drops `title` and adds not-null to `name`

### DIFF
--- a/db/migrations/20180228153542_create_movies.js
+++ b/db/migrations/20180228153542_create_movies.js
@@ -1,7 +1,9 @@
 'use strict';
 
+const MOVIES = 'movies';
+
 exports.up = (Knex, Promise) => {
-  return Knex.schema.createTable('movies', (table) => {
+  return Knex.schema.createTable(MOVIES, (table) => {
     table.increments('id').primary();
     table.text('title').notNullable();
     table.integer('release_year');
@@ -9,5 +11,5 @@ exports.up = (Knex, Promise) => {
 };
 
 exports.down = (Knex, Promise) => {
-  return Knex.schema.dropTable('movies');
+  return Knex.schema.dropTable(MOVIES);
 };

--- a/db/migrations/20180302131905_add_name_to_movies.js
+++ b/db/migrations/20180302131905_add_name_to_movies.js
@@ -1,7 +1,9 @@
 'use strict';
 
+const MOVIES = 'movies';
+
 exports.up = (Knex, Promise) => {
-  return Knex.schema.table('movies', (table) => {
+  return Knex.schema.table(MOVIES, (table) => {
     table.text('name');
   })
   .then(() => {
@@ -10,7 +12,7 @@ exports.up = (Knex, Promise) => {
 };
 
 exports.down = (Knex, Promise) => {
-  return Knex.schema.table('movies', (table) => {
+  return Knex.schema.table(MOVIES, (table) => {
     table.dropColumn('name');
   })
   .then(() => {

--- a/db/migrations/20180302174739_backfill_movies_name.js
+++ b/db/migrations/20180302174739_backfill_movies_name.js
@@ -1,7 +1,9 @@
 'use strict';
 
+const MOVIES = 'movies';
+
 exports.up = (Knex, Promise) => {
-  return Knex.raw('UPDATE movies SET name = title WHERE name IS NULL');
+  return Knex.raw(`UPDATE ${MOVIES} SET name = title WHERE name IS NULL`);
 };
 
 exports.down = (Knex, Promise) => {

--- a/db/migrations/20180305163558_drop_title_from_movies.js
+++ b/db/migrations/20180305163558_drop_title_from_movies.js
@@ -1,0 +1,19 @@
+'use strict';
+
+exports.up = (Knex) => {
+  return Knex.schema.table('movies', (table) => {
+    table.dropColumn('title');
+  })
+  .then(() => {
+    return Knex.raw('ALTER TABLE movies ALTER COLUMN name SET NOT NULL');
+  });
+};
+
+exports.down = (Knex) => {
+  return Knex.schema.table('movies', (table) => {
+    table.text('title');
+  })
+  .then(() => {
+    return Knex.raw('ALTER TABLE movies ALTER COLUMN name DROP NOT NULL');
+  });
+};

--- a/db/migrations/20180305163558_drop_title_from_movies.js
+++ b/db/migrations/20180305163558_drop_title_from_movies.js
@@ -1,7 +1,9 @@
 'use strict';
 
+const MOVIES = 'movies';
+
 exports.up = (Knex) => {
-  return Knex.schema.table('movies', (table) => {
+  return Knex.schema.table(MOVIES, (table) => {
     table.dropColumn('title');
   })
   .then(() => {
@@ -10,7 +12,7 @@ exports.up = (Knex) => {
 };
 
 exports.down = (Knex) => {
-  return Knex.schema.table('movies', (table) => {
+  return Knex.schema.table(MOVIES, (table) => {
     table.text('title');
   })
   .then(() => {

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -11,7 +11,7 @@ describe('movie controller', () => {
 
       return Controller.create(payload)
       .then((movie) => {
-        expect(movie.get('title')).to.eql(null);
+        expect(movie.get('title')).to.be.undefined;
         expect(movie.get('name')).to.eql(payload.name);
       });
     });

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -11,7 +11,6 @@ describe('movie controller', () => {
 
       return Controller.create(payload)
       .then((movie) => {
-        expect(movie.get('title')).to.be.undefined;
         expect(movie.get('name')).to.eql(payload.name);
       });
     });


### PR DESCRIPTION
**What:**
- Drops `title` column
- Adds not-null constraint to `name`

**Why:**
This is the final step to the zero-downtime migration.

**Context:**
Previous PR: #7, updates the application code to stop adding to the `title` column
Next PR: add GET /movies endpoint