### PR TITLE
feat(GET /movies): Adds endpoint with unit and integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
 before_script:
   - yarn db:setup:user
   - yarn db:reset
-  - psql -c 'CREATE EXTENSION fuzzystrmatch;' -U sfmovies_user
+  - psql --username postgres --dbname sfmovies_test -c 'CREATE EXTENSION fuzzystrmatch;'
 script:
   - yarn lint
   - yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
 before_script:
   - yarn db:setup:user
   - yarn db:reset
-  - psql --username postgres --dbname sfmovies_test -c 'CREATE EXTENSION fuzzystrmatch;'
 script:
   - yarn lint
   - yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
 before_script:
   - yarn db:setup:user
   - yarn db:reset
+  - psql -c 'CREATE EXTENSION fuzzystrmatch;' -U sfmovies_user
 script:
   - yarn lint
   - yarn test

--- a/config/development.js
+++ b/config/development.js
@@ -5,6 +5,6 @@ module.exports = {
   DB_NAME: 'sfmovies_development',
   DB_PASSWORD: '',
   DB_PORT: 5432,
-  DB_USER: 'johnkim',
+  DB_USER: 'postgres',
   PORT: 3000
 };

--- a/config/development.js
+++ b/config/development.js
@@ -5,6 +5,6 @@ module.exports = {
   DB_NAME: 'sfmovies_development',
   DB_PASSWORD: '',
   DB_PORT: 5432,
-  DB_USER: 'sfmovies_user',
+  DB_USER: 'johnkim',
   PORT: 3000
 };

--- a/config/development.js
+++ b/config/development.js
@@ -5,6 +5,6 @@ module.exports = {
   DB_NAME: 'sfmovies_development',
   DB_PASSWORD: '',
   DB_PORT: 5432,
-  DB_USER: 'postgres',
+  DB_USER: 'sfmovies_user',
   PORT: 3000
 };

--- a/config/test.js
+++ b/config/test.js
@@ -5,6 +5,6 @@ module.exports = {
   DB_NAME: 'sfmovies_test',
   DB_PASSWORD: '',
   DB_PORT: 5432,
-  DB_USER: 'postgres',
+  DB_USER: 'sfmovies_user',
   PORT: 3000
 };

--- a/config/test.js
+++ b/config/test.js
@@ -5,6 +5,6 @@ module.exports = {
   DB_NAME: 'sfmovies_test',
   DB_PASSWORD: '',
   DB_PORT: 5432,
-  DB_USER: 'johnkim',
+  DB_USER: 'postgres',
   PORT: 3000
 };

--- a/config/test.js
+++ b/config/test.js
@@ -5,6 +5,6 @@ module.exports = {
   DB_NAME: 'sfmovies_test',
   DB_PASSWORD: '',
   DB_PORT: 5432,
-  DB_USER: 'sfmovies_user',
+  DB_USER: 'johnkim',
   PORT: 3000
 };

--- a/db/migrations/20180309165014_add_extension_fuzzystrmatch.js
+++ b/db/migrations/20180309165014_add_extension_fuzzystrmatch.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.up = (Knex) => {
+  return Knex.raw('CREATE EXTENSION fuzzystrmatch;');
+};
+
+exports.down = (Knex, Promise) => {
+  return Promise.resolve();
+};

--- a/db/seeds/data/movies.json
+++ b/db/seeds/data/movies.json
@@ -1,1096 +1,1096 @@
 [{
-  "title": "180",
+  "name": "180",
   "release_year": 2011
 },
 {
-  "title": "24 Hours on Craigslist",
+  "name": "24 Hours on Craigslist",
   "release_year": 2005
 },
 {
-  "title": "40 Days and 40 Nights",
+  "name": "40 Days and 40 Nights",
   "release_year": 2002
 },
 {
-  "title": "48 Hours",
+  "name": "48 Hours",
   "release_year": 1982
 },
 {
-  "title": "50 First Dates",
+  "name": "50 First Dates",
   "release_year": 2004
 },
 {
-  "title": "A Jitney Elopement",
+  "name": "A Jitney Elopement",
   "release_year": 1915
 },
 {
-  "title": "A Night Full of Rain",
+  "name": "A Night Full of Rain",
   "release_year": 1978
 },
 {
-  "title": "A Smile Like Yours",
+  "name": "A Smile Like Yours",
   "release_year": 1997
 },
 {
-  "title": "A View to a Kill",
+  "name": "A View to a Kill",
   "release_year": 1985
 },
 {
-  "title": "About a Boy",
+  "name": "About a Boy",
   "release_year": 2014
 },
 {
-  "title": "After the Thin Man",
+  "name": "After the Thin Man",
   "release_year": 1936
 },
 {
-  "title": "Age of Adaline",
+  "name": "Age of Adaline",
   "release_year": 2015
 },
 {
-  "title": "Alcatraz",
+  "name": "Alcatraz",
   "release_year": 2012
 },
 {
-  "title": "Alexander's Ragtime Band",
+  "name": "Alexander's Ragtime Band",
   "release_year": 1938
 },
 {
-  "title": "All About Eve",
+  "name": "All About Eve",
   "release_year": 1950
 },
 {
-  "title": "American Graffiti",
+  "name": "American Graffiti",
   "release_year": 1973
 },
 {
-  "title": "American Yearbook",
+  "name": "American Yearbook",
   "release_year": 2004
 },
 {
-  "title": "Americana",
+  "name": "Americana",
   "release_year": 2015
 },
 {
-  "title": "Another 48 Hours",
+  "name": "Another 48 Hours",
   "release_year": 1990
 },
 {
-  "title": "Ant-Man",
+  "name": "Ant-Man",
   "release_year": 2015
 },
 {
-  "title": "Around the Fire",
+  "name": "Around the Fire",
   "release_year": 1998
 },
 {
-  "title": "Attack of the Killer Tomatoes",
+  "name": "Attack of the Killer Tomatoes",
   "release_year": 1978
 },
 {
-  "title": "Babies",
+  "name": "Babies",
   "release_year": 2010
 },
 {
-  "title": "Barbary Coast",
+  "name": "Barbary Coast",
   "release_year": 1935
 },
 {
-  "title": "Basic Instinct",
+  "name": "Basic Instinct",
   "release_year": 1992
 },
 {
-  "title": "Beaches",
+  "name": "Beaches",
   "release_year": 1988
 },
 {
-  "title": "Bedazzled",
+  "name": "Bedazzled",
   "release_year": 2000
 },
 {
-  "title": "Bee Season",
+  "name": "Bee Season",
   "release_year": 2005
 },
 {
-  "title": "Bicentennial Man",
+  "name": "Bicentennial Man",
   "release_year": 1999
 },
 {
-  "title": "Big Eyes",
+  "name": "Big Eyes",
   "release_year": 2014
 },
 {
-  "title": "Big Sur",
+  "name": "Big Sur",
   "release_year": 2013
 },
 {
-  "title": "Big Touble in Little China",
+  "name": "Big Touble in Little China",
   "release_year": 1986
 },
 {
-  "title": "Birdman of Alcatraz",
+  "name": "Birdman of Alcatraz",
   "release_year": 1962
 },
 {
-  "title": "Blue Jasmine",
+  "name": "Blue Jasmine",
   "release_year": 2013
 },
 {
-  "title": "Boys and Girls",
+  "name": "Boys and Girls",
   "release_year": 2000
 },
 {
-  "title": "Broken-A Modern Love Story",
+  "name": "Broken-A Modern Love Story",
   "release_year": 2010
 },
 {
-  "title": "Bullitt",
+  "name": "Bullitt",
   "release_year": 1968
 },
 {
-  "title": "Burglar",
+  "name": "Burglar",
   "release_year": 1987
 },
 {
-  "title": "By Hook or By Crook",
+  "name": "By Hook or By Crook",
   "release_year": 2001
 },
 {
-  "title": "Can't Stop the Music",
+  "name": "Can't Stop the Music",
   "release_year": 1980
 },
 {
-  "title": "Cardinal X",
+  "name": "Cardinal X",
   "release_year": 2015
 },
 {
-  "title": "Casualties of War",
+  "name": "Casualties of War",
   "release_year": 1989
 },
 {
-  "title": "Chan is Missing",
+  "name": "Chan is Missing",
   "release_year": 1982
 },
 {
-  "title": "Cherish",
+  "name": "Cherish",
   "release_year": 2002
 },
 {
-  "title": "Chu Chu and the Philly Flash",
+  "name": "Chu Chu and the Philly Flash",
   "release_year": 1981
 },
 {
-  "title": "City of Angels",
+  "name": "City of Angels",
   "release_year": 1998
 },
 {
-  "title": "Class Action",
+  "name": "Class Action",
   "release_year": 1991
 },
 {
-  "title": "Common Threads: Stories From the Quilt",
+  "name": "Common Threads: Stories From the Quilt",
   "release_year": 1989
 },
 {
-  "title": "Confessions of a Burning Man",
+  "name": "Confessions of a Burning Man",
   "release_year": 2003
 },
 {
-  "title": "Copycat",
+  "name": "Copycat",
   "release_year": 1995
 },
 {
-  "title": "Crackers",
+  "name": "Crackers",
   "release_year": 1984
 },
 {
-  "title": "CSI: NY- episode 903",
+  "name": "CSI: NY- episode 903",
   "release_year": 2012
 },
 {
-  "title": "D.O.A",
+  "name": "D.O.A",
   "release_year": 1950
 },
 {
-  "title": "Dark Passage",
+  "name": "Dark Passage",
   "release_year": 1947
 },
 {
-  "title": "Dawn of the Planet of the Apes",
+  "name": "Dawn of the Planet of the Apes",
   "release_year": 2014
 },
 {
-  "title": "Days of Wine and Roses",
+  "name": "Days of Wine and Roses",
   "release_year": 1962
 },
 {
-  "title": "Desperate Measures",
+  "name": "Desperate Measures",
   "release_year": 1998
 },
 {
-  "title": "Dim Sum: A Little Bit of Heart",
+  "name": "Dim Sum: A Little Bit of Heart",
   "release_year": 1985
 },
 {
-  "title": "Dirty Harry",
+  "name": "Dirty Harry",
   "release_year": 1971
 },
 {
-  "title": "Doctor Dolittle",
+  "name": "Doctor Dolittle",
   "release_year": 1998
 },
 {
-  "title": "Dopamine",
+  "name": "Dopamine",
   "release_year": 2003
 },
 {
-  "title": "Down Periscope",
+  "name": "Down Periscope",
   "release_year": 1996
 },
 {
-  "title": "Dr. Dolittle 2",
+  "name": "Dr. Dolittle 2",
   "release_year": 2001
 },
 {
-  "title": "Dream for an Insomniac",
+  "name": "Dream for an Insomniac",
   "release_year": 1996
 },
 {
-  "title": "Dream with the Fishes",
+  "name": "Dream with the Fishes",
   "release_year": 1997
 },
 {
-  "title": "Dying Young",
+  "name": "Dying Young",
   "release_year": 1991
 },
 {
-  "title": "Edtv",
+  "name": "Edtv",
   "release_year": 1999
 },
 {
-  "title": "Escape From Alcatraz",
+  "name": "Escape From Alcatraz",
   "release_year": 1979
 },
 {
-  "title": "Experiment in Terror",
+  "name": "Experiment in Terror",
   "release_year": 1962
 },
 {
-  "title": "Faces of Death",
+  "name": "Faces of Death",
   "release_year": 1978
 },
 {
-  "title": "Family Plot",
+  "name": "Family Plot",
   "release_year": 1976
 },
 {
-  "title": "Fandom",
+  "name": "Fandom",
   "release_year": 2004
 },
 {
-  "title": "Fat Man and Little Boy",
+  "name": "Fat Man and Little Boy",
   "release_year": 1989
 },
 {
-  "title": "Fathers' Day",
+  "name": "Fathers' Day",
   "release_year": 1997
 },
 {
-  "title": "Fearless",
+  "name": "Fearless",
   "release_year": 1993
 },
 {
-  "title": "Final Analysis",
+  "name": "Final Analysis",
   "release_year": 1992
 },
 {
-  "title": "Flower Drum Song",
+  "name": "Flower Drum Song",
   "release_year": 1961
 },
 {
-  "title": "Flubber",
+  "name": "Flubber",
   "release_year": 1997
 },
 {
-  "title": "Forrest Gump",
+  "name": "Forrest Gump",
   "release_year": 1994
 },
 {
-  "title": "Foul Play",
+  "name": "Foul Play",
   "release_year": 1978
 },
 {
-  "title": "Freebie and the Bean",
+  "name": "Freebie and the Bean",
   "release_year": 1974
 },
 {
-  "title": "Gentleman Jim",
+  "name": "Gentleman Jim",
   "release_year": 1942
 },
 {
-  "title": "George of the Jungle",
+  "name": "George of the Jungle",
   "release_year": 1997
 },
 {
-  "title": "Getting Even with Dad",
+  "name": "Getting Even with Dad",
   "release_year": 1994
 },
 {
-  "title": "God is a Communist?* (show me heart universe)",
+  "name": "God is a Communist?* (show me heart universe)",
   "release_year": 2010
 },
 {
-  "title": "Godzilla",
+  "name": "Godzilla",
   "release_year": 2014
 },
 {
-  "title": "Golden Gate",
+  "name": "Golden Gate",
   "release_year": 1994
 },
 {
-  "title": "Golden Gate",
+  "name": "Golden Gate",
   "release_year": 1994
 },
 {
-  "title": "Greed",
+  "name": "Greed",
   "release_year": 1924
 },
 {
-  "title": "Groove",
+  "name": "Groove",
   "release_year": 2000
 },
 {
-  "title": "Guess Who's Coming to Dinner",
+  "name": "Guess Who's Coming to Dinner",
   "release_year": 1967
 },
 {
-  "title": "Haiku Tunnel",
+  "name": "Haiku Tunnel",
   "release_year": 2001
 },
 {
-  "title": "Happy Gilmore",
+  "name": "Happy Gilmore",
   "release_year": 1996
 },
 {
-  "title": "Hard to Hold",
+  "name": "Hard to Hold",
   "release_year": 1984
 },
 {
-  "title": "Harold and Maude",
+  "name": "Harold and Maude",
   "release_year": 1971
 },
 {
-  "title": "Heart and Souls",
+  "name": "Heart and Souls",
   "release_year": 1993
 },
 {
-  "title": "Heart Beat",
+  "name": "Heart Beat",
   "release_year": 1980
 },
 {
-  "title": "Hello Frisco, Hello",
+  "name": "Hello Frisco, Hello",
   "release_year": 1943
 },
 {
-  "title": "Hemingway & Gelhorn",
+  "name": "Hemingway & Gelhorn",
   "release_year": 2011
 },
 {
-  "title": "Herbie Rides Again",
+  "name": "Herbie Rides Again",
   "release_year": 1974
 },
 {
-  "title": "Hereafter",
+  "name": "Hereafter",
   "release_year": 2010
 },
 {
-  "title": "High Anxiety",
+  "name": "High Anxiety",
   "release_year": 1977
 },
 {
-  "title": "High Crimes",
+  "name": "High Crimes",
   "release_year": 2002
 },
 {
-  "title": "Homeward Bound II: Lost in San Francisco",
+  "name": "Homeward Bound II: Lost in San Francisco",
   "release_year": 1996
 },
 {
-  "title": "House of Sand and Fog",
+  "name": "House of Sand and Fog",
   "release_year": 2003
 },
 {
-  "title": "How Stella Got Her Groove Back",
+  "name": "How Stella Got Her Groove Back",
   "release_year": 1998
 },
 {
-  "title": "Hulk",
+  "name": "Hulk",
   "release_year": 2003
 },
 {
-  "title": "I Am Michael",
+  "name": "I Am Michael",
   "release_year": 2015
 },
 {
-  "title": "I Remember Mama",
+  "name": "I Remember Mama",
   "release_year": 1948
 },
 {
-  "title": "I's",
+  "name": "I's",
   "release_year": 2011
 },
 {
-  "title": "Indiana Jones and the Last Crusade",
+  "name": "Indiana Jones and the Last Crusade",
   "release_year": 1989
 },
 {
-  "title": "Innerspace",
+  "name": "Innerspace",
   "release_year": 1987
 },
 {
-  "title": "Interview With The Vampire",
+  "name": "Interview With The Vampire",
   "release_year": 1994
 },
 {
-  "title": "Invasion of the Body Snatchers",
+  "name": "Invasion of the Body Snatchers",
   "release_year": 1978
 },
 {
-  "title": "It Came From Beneath the Sea",
+  "name": "It Came From Beneath the Sea",
   "release_year": 1955
 },
 {
-  "title": "Jack",
+  "name": "Jack",
   "release_year": 1996
 },
 {
-  "title": "Jade",
+  "name": "Jade",
   "release_year": 1995
 },
 {
-  "title": "Jagged Edge",
+  "name": "Jagged Edge",
   "release_year": 1985
 },
 {
-  "title": "James and the Giant Peach",
+  "name": "James and the Giant Peach",
   "release_year": 1996
 },
 {
-  "title": "Joy Luck Club",
+  "name": "Joy Luck Club",
   "release_year": 1993
 },
 {
-  "title": "Julie and Jack",
+  "name": "Julie and Jack",
   "release_year": 2003
 },
 {
-  "title": "Junior",
+  "name": "Junior",
   "release_year": 1994
 },
 {
-  "title": "Just Like Heaven",
+  "name": "Just Like Heaven",
   "release_year": 2005
 },
 {
-  "title": "Just One Night",
+  "name": "Just One Night",
   "release_year": 2000
 },
 {
-  "title": "Kamikaze Hearts",
+  "name": "Kamikaze Hearts",
   "release_year": 1986
 },
 {
-  "title": "Knife Fight",
+  "name": "Knife Fight",
   "release_year": 2013
 },
 {
-  "title": "Live Nude Girls Unite",
+  "name": "Live Nude Girls Unite",
   "release_year": 2000
 },
 {
-  "title": "Looking",
+  "name": "Looking",
   "release_year": 2014
 },
 {
-  "title": "Love & Taxes",
+  "name": "Love & Taxes",
   "release_year": 2014
 },
 {
-  "title": "Magnum Force",
+  "name": "Magnum Force",
   "release_year": 1973
 },
 {
-  "title": "Marnie",
+  "name": "Marnie",
   "release_year": 1964
 },
 {
-  "title": "Maxie",
+  "name": "Maxie",
   "release_year": 1985
 },
 {
-  "title": "Memoirs of an Invisible Man",
+  "name": "Memoirs of an Invisible Man",
   "release_year": 1992
 },
 {
-  "title": "Metro",
+  "name": "Metro",
   "release_year": 1997
 },
 {
-  "title": "Midnight Lace",
+  "name": "Midnight Lace",
   "release_year": 1960
 },
 {
-  "title": "Milk",
+  "name": "Milk",
   "release_year": 2008
 },
 {
-  "title": "Mission (aka City of Bars)",
+  "name": "Mission (aka City of Bars)",
   "release_year": 2001
 },
 {
-  "title": "Mona Lisa Smile",
+  "name": "Mona Lisa Smile",
   "release_year": 2003
 },
 {
-  "title": "Mother",
+  "name": "Mother",
   "release_year": 1996
 },
 {
-  "title": "Mrs. Doubtfire",
+  "name": "Mrs. Doubtfire",
   "release_year": 1993
 },
 {
-  "title": "Murder in the First",
+  "name": "Murder in the First",
   "release_year": 2014
 },
 {
-  "title": "Murder in the First",
+  "name": "Murder in the First",
   "release_year": 1995
 },
 {
-  "title": "My Reality",
+  "name": "My Reality",
   "release_year": 2011
 },
 {
-  "title": "Need For Speed",
+  "name": "Need For Speed",
   "release_year": 2014
 },
 {
-  "title": "Never Die Twice",
+  "name": "Never Die Twice",
   "release_year": 2001
 },
 {
-  "title": "Night of Henna",
+  "name": "Night of Henna",
   "release_year": 2005
 },
 {
-  "title": "Nina Takes a Lover",
+  "name": "Nina Takes a Lover",
   "release_year": 1994
 },
 {
-  "title": "Nine Months",
+  "name": "Nine Months",
   "release_year": 1995
 },
 {
-  "title": "Nine to Five",
+  "name": "Nine to Five",
   "release_year": 1980
 },
 {
-  "title": "Nora Prentiss",
+  "name": "Nora Prentiss",
   "release_year": 1947
 },
 {
-  "title": "On the Beach",
+  "name": "On the Beach",
   "release_year": 1959
 },
 {
-  "title": "On the Road",
+  "name": "On the Road",
   "release_year": 2012
 },
 {
-  "title": "Pacific Heights",
+  "name": "Pacific Heights",
   "release_year": 1990
 },
 {
-  "title": "Pal Joey",
+  "name": "Pal Joey",
   "release_year": 1957
 },
 {
-  "title": "Panther",
+  "name": "Panther",
   "release_year": 1995
 },
 {
-  "title": "Parks and Recreation",
+  "name": "Parks and Recreation",
   "release_year": 2014
 },
 {
-  "title": "Patch Adams",
+  "name": "Patch Adams",
   "release_year": 1998
 },
 {
-  "title": "Patty Hearst",
+  "name": "Patty Hearst",
   "release_year": 1988
 },
 {
-  "title": "Petulia",
+  "name": "Petulia",
   "release_year": 1968
 },
 {
-  "title": "Phenomenon",
+  "name": "Phenomenon",
   "release_year": 1996
 },
 {
-  "title": "Play it Again, Sam",
+  "name": "Play it Again, Sam",
   "release_year": 1972
 },
 {
-  "title": "Playing Mona Lisa",
+  "name": "Playing Mona Lisa",
   "release_year": 2000
 },
 {
-  "title": "Pleasure of His Company",
+  "name": "Pleasure of His Company",
   "release_year": 1961
 },
 {
-  "title": "Point Blank",
+  "name": "Point Blank",
   "release_year": 1967
 },
 {
-  "title": "Pretty Woman",
+  "name": "Pretty Woman",
   "release_year": 1990
 },
 {
-  "title": "Psych-Out",
+  "name": "Psych-Out",
   "release_year": 1968
 },
 {
-  "title": "Quicksilver",
+  "name": "Quicksilver",
   "release_year": 1986
 },
 {
-  "title": "Quitters",
+  "name": "Quitters",
   "release_year": 2015
 },
 {
-  "title": "Raising Cain",
+  "name": "Raising Cain",
   "release_year": 1992
 },
 {
-  "title": "Red Diaper Baby",
+  "name": "Red Diaper Baby",
   "release_year": 2004
 },
 {
-  "title": "Red Widow",
+  "name": "Red Widow",
   "release_year": 2013
 },
 {
-  "title": "Rent",
+  "name": "Rent",
   "release_year": 2005
 },
 {
-  "title": "Rollerball",
+  "name": "Rollerball",
   "release_year": 2002
 },
 {
-  "title": "Romeo Must Die",
+  "name": "Romeo Must Die",
   "release_year": 2000
 },
 {
-  "title": "San Andreas",
+  "name": "San Andreas",
   "release_year": 2015
 },
 {
-  "title": "San Francisco",
+  "name": "San Francisco",
   "release_year": 1936
 },
 {
-  "title": "Sausalito",
+  "name": "Sausalito",
   "release_year": 2000
 },
 {
-  "title": "Sense8",
+  "name": "Sense8",
   "release_year": 2015
 },
 {
-  "title": "Serendipity",
+  "name": "Serendipity",
   "release_year": 2001
 },
 {
-  "title": "Serial",
+  "name": "Serial",
   "release_year": 1980
 },
 {
-  "title": "Seven Girlfriends",
+  "name": "Seven Girlfriends",
   "release_year": 1999
 },
 {
-  "title": "Shadow of the Thin Man",
+  "name": "Shadow of the Thin Man",
   "release_year": 1941
 },
 {
-  "title": "Shattered",
+  "name": "Shattered",
   "release_year": 1991
 },
 {
-  "title": "Shoot the Moon",
+  "name": "Shoot the Moon",
   "release_year": 1982
 },
 {
-  "title": "Sister Act",
+  "name": "Sister Act",
   "release_year": 1992
 },
 {
-  "title": "Sister Act 2: Back in the Habit",
+  "name": "Sister Act 2: Back in the Habit",
   "release_year": 1993
 },
 {
-  "title": "Smile Again, Jenny Lee",
+  "name": "Smile Again, Jenny Lee",
   "release_year": 2015
 },
 {
-  "title": "Sneakers",
+  "name": "Sneakers",
   "release_year": 1992
 },
 {
-  "title": "So I Married an Axe Murderer",
+  "name": "So I Married an Axe Murderer",
   "release_year": 1993
 },
 {
-  "title": "Sphere",
+  "name": "Sphere",
   "release_year": 1998
 },
 {
-  "title": "Star Trek II : The Wrath of Khan",
+  "name": "Star Trek II : The Wrath of Khan",
   "release_year": 1982
 },
 {
-  "title": "Star Trek IV: The Voyage Home",
+  "name": "Star Trek IV: The Voyage Home",
   "release_year": 1986
 },
 {
-  "title": "Star Trek VI: The Undiscovered Country",
+  "name": "Star Trek VI: The Undiscovered Country",
   "release_year": 1991
 },
 {
-  "title": "Steve Jobs",
+  "name": "Steve Jobs",
   "release_year": 2015
 },
 {
-  "title": "Stigmata",
+  "name": "Stigmata",
   "release_year": 1999
 },
 {
-  "title": "Street Music",
+  "name": "Street Music",
   "release_year": 1981
 },
 {
-  "title": "Sudden Fear",
+  "name": "Sudden Fear",
   "release_year": 1952
 },
 {
-  "title": "Sudden Impact",
+  "name": "Sudden Impact",
   "release_year": 1983
 },
 {
-  "title": "Summertime",
+  "name": "Summertime",
   "release_year": 2015
 },
 {
-  "title": "Superman",
+  "name": "Superman",
   "release_year": 1978
 },
 {
-  "title": "Susan Slade",
+  "name": "Susan Slade",
   "release_year": 1961
 },
 {
-  "title": "Sweet November",
+  "name": "Sweet November",
   "release_year": 2001
 },
 {
-  "title": "Swing",
+  "name": "Swing",
   "release_year": 2003
 },
 {
-  "title": "Swingin' Along",
+  "name": "Swingin' Along",
   "release_year": 1961
 },
 {
-  "title": "Take the Money and Run",
+  "name": "Take the Money and Run",
   "release_year": 1969
 },
 {
-  "title": "Terminator - Genisys",
+  "name": "Terminator - Genisys",
   "release_year": 2015
 },
 {
-  "title": "The Assassination of Richard Nixon",
+  "name": "The Assassination of Richard Nixon",
   "release_year": 2004
 },
 {
-  "title": "The Bachelor",
+  "name": "The Bachelor",
   "release_year": 1999
 },
 {
-  "title": "The Birds",
+  "name": "The Birds",
   "release_year": 1963
 },
 {
-  "title": "The Bridge",
+  "name": "The Bridge",
   "release_year": 2006
 },
 {
-  "title": "The Caine Mutiny",
+  "name": "The Caine Mutiny",
   "release_year": 1954
 },
 {
-  "title": "The Californians",
+  "name": "The Californians",
   "release_year": 2005
 },
 {
-  "title": "The Candidate",
+  "name": "The Candidate",
   "release_year": 1972
 },
 {
-  "title": "The Competition",
+  "name": "The Competition",
   "release_year": 1980
 },
 {
-  "title": "The Conversation",
+  "name": "The Conversation",
   "release_year": 1974
 },
 {
-  "title": "The Core",
+  "name": "The Core",
   "release_year": 2003
 },
 {
-  "title": "The Dead Pool",
+  "name": "The Dead Pool",
   "release_year": 1988
 },
 {
-  "title": "The Diary of a Teenage Girl",
+  "name": "The Diary of a Teenage Girl",
   "release_year": 2015
 },
 {
-  "title": "The Doctor",
+  "name": "The Doctor",
   "release_year": 1991
 },
 {
-  "title": "The Doors",
+  "name": "The Doors",
   "release_year": 1991
 },
 {
-  "title": "The Enforcer",
+  "name": "The Enforcer",
   "release_year": 1976
 },
 {
-  "title": "The Fan",
+  "name": "The Fan",
   "release_year": 1996
 },
 {
-  "title": "The Fog of War",
+  "name": "The Fog of War",
   "release_year": 2003
 },
 {
-  "title": "The Game",
+  "name": "The Game",
   "release_year": 1997
 },
 {
-  "title": "The Graduate",
+  "name": "The Graduate",
   "release_year": 1967
 },
 {
-  "title": "The House on Telegraph Hill",
+  "name": "The House on Telegraph Hill",
   "release_year": 1951
 },
 {
-  "title": "The Internship",
+  "name": "The Internship",
   "release_year": 2013
 },
 {
-  "title": "The Jazz Singer",
+  "name": "The Jazz Singer",
   "release_year": 1927
 },
 {
-  "title": "The Lady from Shanghai",
+  "name": "The Lady from Shanghai",
   "release_year": 1947
 },
 {
-  "title": "The Last of the Gladiators",
+  "name": "The Last of the Gladiators",
   "release_year": 1988
 },
 {
-  "title": "The Laughing Policeman",
+  "name": "The Laughing Policeman",
   "release_year": 1973
 },
 {
-  "title": "The Lineup",
+  "name": "The Lineup",
   "release_year": 1958
 },
 {
-  "title": "The Love Bug",
+  "name": "The Love Bug",
   "release_year": 1968
 },
 {
-  "title": "The Maltese Falcon",
+  "name": "The Maltese Falcon",
   "release_year": 1941
 },
 {
-  "title": "The Master",
+  "name": "The Master",
   "release_year": 2012
 },
 {
-  "title": "The Matrix",
+  "name": "The Matrix",
   "release_year": 1999
 },
 {
-  "title": "The Net",
+  "name": "The Net",
   "release_year": 1995
 },
 {
-  "title": "The Nightmare Before Christmas",
+  "name": "The Nightmare Before Christmas",
   "release_year": 1993
 },
 {
-  "title": "The Organization",
+  "name": "The Organization",
   "release_year": 1971
 },
 {
-  "title": "The Other Sister",
+  "name": "The Other Sister",
   "release_year": 1999
 },
 {
-  "title": "The Parent Trap",
+  "name": "The Parent Trap",
   "release_year": 1998
 },
 {
-  "title": "The Presidio",
+  "name": "The Presidio",
   "release_year": 1988
 },
 {
-  "title": "The Princess Diaries",
+  "name": "The Princess Diaries",
   "release_year": 2001
 },
 {
-  "title": "The Pursuit of Happyness",
+  "name": "The Pursuit of Happyness",
   "release_year": 2006
 },
 {
-  "title": "The Right Stuff",
+  "name": "The Right Stuff",
   "release_year": 1983
 },
 {
-  "title": "The Rock",
+  "name": "The Rock",
   "release_year": 1996
 },
 {
-  "title": "The Sweetest Thing",
+  "name": "The Sweetest Thing",
   "release_year": 2002
 },
 {
-  "title": "The Ten Commandments",
+  "name": "The Ten Commandments",
   "release_year": 1923
 },
 {
-  "title": "The Times of Harvey Milk",
+  "name": "The Times of Harvey Milk",
   "release_year": 1984
 },
 {
-  "title": "The Towering Inferno",
+  "name": "The Towering Inferno",
   "release_year": 1974
 },
 {
-  "title": "The Wedding Planner",
+  "name": "The Wedding Planner",
   "release_year": 2001
 },
 {
-  "title": "The Woman In Red",
+  "name": "The Woman In Red",
   "release_year": 1984
 },
 {
-  "title": "The Zodiac",
+  "name": "The Zodiac",
   "release_year": 2005
 },
 {
-  "title": "They Call Me MISTER Tibbs",
+  "name": "They Call Me MISTER Tibbs",
   "release_year": 1970
 },
 {
-  "title": "Thief of Hearts",
+  "name": "Thief of Hearts",
   "release_year": 1984
 },
 {
-  "title": "Time After Time",
+  "name": "Time After Time",
   "release_year": 1979
 },
 {
-  "title": "Tin Cup",
+  "name": "Tin Cup",
   "release_year": 1996
 },
 {
-  "title": "To the Ends of the Earth",
+  "name": "To the Ends of the Earth",
   "release_year": 1948
 },
 {
-  "title": "True Believer",
+  "name": "True Believer",
   "release_year": 1989
 },
 {
-  "title": "Tucker: The Man and His Dream",
+  "name": "Tucker: The Man and His Dream",
   "release_year": 1988
 },
 {
-  "title": "Tweek City",
+  "name": "Tweek City",
   "release_year": 2005
 },
 {
-  "title": "Twisted",
+  "name": "Twisted",
   "release_year": 2004
 },
 {
-  "title": "Under the Tuscan Sun",
+  "name": "Under the Tuscan Sun",
   "release_year": 2003
 },
 {
-  "title": "Until the End of the World",
+  "name": "Until the End of the World",
   "release_year": 1991
 },
 {
-  "title": "Vegas in Space",
+  "name": "Vegas in Space",
   "release_year": 1992
 },
 {
-  "title": "Vertigo",
+  "name": "Vertigo",
   "release_year": 1958
 },
 {
-  "title": "What Dreams May Come",
+  "name": "What Dreams May Come",
   "release_year": 1998
 },
 {
-  "title": "What the Bleep Do We Know",
+  "name": "What the Bleep Do We Know",
   "release_year": 2004
 },
 {
-  "title": "What's Up Doc?",
+  "name": "What's Up Doc?",
   "release_year": 1972
 },
 {
-  "title": "When a Man Loves a Woman",
+  "name": "When a Man Loves a Woman",
   "release_year": 1994
 },
 {
-  "title": "Woman on the Run",
+  "name": "Woman on the Run",
   "release_year": 1950
 },
 {
-  "title": "Woman on Top",
+  "name": "Woman on Top",
   "release_year": 2000
 },
 {
-  "title": "Yours, Mine and Ours",
+  "name": "Yours, Mine and Ours",
   "release_year": 1968
 },
 {
-  "title": "Zodiac",
+  "name": "Zodiac",
   "release_year": 2007
 }]

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -2,13 +2,24 @@
 
 const Movie = require('../../../models/movie');
 
+const renameTitleToName = (obj) => {
+  obj.name = obj.title;
+  Reflect.deleteProperty(obj, 'title');
+};
+
 exports.create = (payload) => {
-  payload.name = payload.title;
-  Reflect.deleteProperty(payload, 'title');
+  renameTitleToName(payload);
   return new Movie().save(payload)
   .then((movie) => new Movie({ id: movie.id }).fetch());
 };
 
-exports.get = (payload) => {
-  return new Movie({ id: payload.id }).fetch();
+exports.get = (query) => {
+  if (Object.keys(query).length > 0) {
+    if (query.title) {
+      renameTitleToName(query);
+    }
+    return new Movie(query).fetch();
+  } else {
+    return new Movie().fetchAll();
+  }
 };

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const Movie = require('../../../models/movie');
+const Movie  = require('../../../models/movie');
+const Search = require('./search');
 
 const renameTitleToName = (obj) => {
   obj.name = obj.title;
@@ -14,12 +15,8 @@ exports.create = (payload) => {
 };
 
 exports.get = (query) => {
-  if (Object.keys(query).length > 0) {
-    if (query.title) {
-      renameTitleToName(query);
-    }
-    return new Movie(query).fetch();
-  } else {
-    return new Movie().fetchAll();
+  if (query.title) {
+    renameTitleToName(query);
   }
+  return Search.search(query);
 };

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -8,3 +8,7 @@ exports.create = (payload) => {
   return new Movie().save(payload)
   .then((movie) => new Movie({ id: movie.id }).fetch());
 };
+
+exports.get = (payload) => {
+  return new Movie({ id: payload.id }).fetch();
+};

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -5,18 +5,32 @@ const MovieValidator = require('../../../validators/movie');
 
 exports.register = (server, options, next) => {
 
-  server.route([{
-    method: 'POST',
-    path: '/movies',
-    config: {
-      handler: (request, reply) => {
-        reply(Controller.create(request.payload));
-      },
-      validate: {
-        payload: MovieValidator
+  server.route([
+    {
+      method: 'POST',
+      path: '/movies',
+      config: {
+        handler: (request, reply) => {
+          reply(Controller.create(request.payload));
+        },
+        validate: {
+          payload: MovieValidator.post
+        }
+      }
+    },
+    {
+      method: 'GET',
+      path: '/movies',
+      config: {
+        handler: (request, reply) => {
+          reply(Controller.get(request.payload));
+        },
+        validate: {
+          payload: MovieValidator.get
+        }
       }
     }
-  }]);
+  ]);
 
   next();
 

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -14,7 +14,7 @@ exports.register = (server, options, next) => {
           reply(Controller.create(request.payload));
         },
         validate: {
-          payload: MovieValidator.post
+          payload: MovieValidator.create
         }
       }
     },

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -23,10 +23,10 @@ exports.register = (server, options, next) => {
       path: '/movies',
       config: {
         handler: (request, reply) => {
-          reply(Controller.get(request.payload));
+          reply(Controller.get(request.query));
         },
         validate: {
-          payload: MovieValidator.get
+          query: MovieValidator.get
         }
       }
     }

--- a/lib/plugins/features/movies/search.js
+++ b/lib/plugins/features/movies/search.js
@@ -2,23 +2,23 @@
 
 const Movie = require('../../../models/movie');
 
-const name_search = (name, table) => {
-  let levenshtein_cost;
+const nameSearch = (name, table) => {
+  let levenshteinCost;
 
   if (name.length <= 2) {
-    levenshtein_cost = 0;
+    levenshteinCost = 0;
   } else if (name.length <= 4) {
-    levenshtein_cost = 1;
+    levenshteinCost = 1;
   } else {
-    levenshtein_cost = Math.round(Math.sqrt(name.length));
+    levenshteinCost = Math.round(Math.sqrt(name.length));
   }
-  const levenshtein_check = `levenshtein(LOWER(${table}.name), LOWER('${name}'), 1, 2, 1) <= ${levenshtein_cost}`;
-  const likeness_check = `${table}.name ILIKE '%${name.replace(' ', '%')}%'`;
+  const levenshteinCheck = `levenshtein(LOWER(${table}.name), LOWER('${name}'), 1, 1, 1) <= ${levenshteinCost}`;
+  const likenessCheck = `${table}.name ILIKE '%${name.replace(' ', '%')}%'`;
 
-  return `${levenshtein_check} OR ${likeness_check}`;
+  return `${levenshteinCheck} OR ${likenessCheck}`;
 };
 
-const release_year_search = (year) => {
+const releaseYearSearch = (year) => {
   const years = year.split('-').sort();
 
   if (years.length > 1) {
@@ -33,45 +33,45 @@ exports.search = (query) => {
   let searchQuery;
 
   if (query.name && (query.release_year || query.release_year_range)) {
-    const nameSearch = name_search(query.name, 'year_filtered');
+    const nameResult = nameSearch(query.name, 'year_filtered');
     const year = query.release_year ? query.release_year.toString() : null;
-    const yearSearch = release_year_search(year || query.release_year_range);
+    const yearResult = releaseYearSearch(year || query.release_year_range);
 
     searchQuery = function (qb) {
       qb.select('*')
       .from(function () {
         this.select('*')
         .from('movies')
-        .whereRaw(yearSearch)
+        .whereRaw(yearResult)
         .as('year_filtered');
       })
-      .whereRaw(nameSearch)
+      .whereRaw(nameResult)
       .orderByRaw(orderByName);
     };
 
   } else if (query.name) {
-    const nameSearch = name_search(query.name, 'movies');
+    const nameResult = nameSearch(query.name, 'movies');
 
     searchQuery = function (qb) {
       qb.select('*')
       .from('movies')
-      .whereRaw(nameSearch)
+      .whereRaw(nameResult)
       .orderByRaw(orderByName);
     };
 
   } else if (query.release_year || query.release_year_range) {
     const year = query.release_year ? query.release_year.toString() : null;
-    const yearSearch = release_year_search(year || query.release_year_range);
+    const yearResult = releaseYearSearch(year || query.release_year_range);
 
     searchQuery = function (qb) {
       qb.select('*')
       .from('movies')
-      .whereRaw(yearSearch)
+      .whereRaw(yearResult)
       .orderBy('release_year');
     };
 
   } else {
-    return new Movie(query).fetchAll();
+    return new Movie().where(query).fetchAll();
   }
 
   return new Movie().query(searchQuery).fetchAll();

--- a/lib/plugins/features/movies/search.js
+++ b/lib/plugins/features/movies/search.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const Movie = require('../../../models/movie');
+
+const name_search = (name, table) => {
+  let levenshtein_cost;
+
+  if (name.length <= 2) {
+    levenshtein_cost = 0;
+  } else if (name.length <= 4) {
+    levenshtein_cost = 1;
+  } else {
+    levenshtein_cost = Math.round(Math.sqrt(name.length));
+  }
+  const levenshtein_check = `levenshtein(LOWER(${table}.name), LOWER('${name}'), 1, 2, 1) <= ${levenshtein_cost}`;
+  const likeness_check = `${table}.name ILIKE '%${name.replace(' ', '%')}%'`;
+
+  return `${levenshtein_check} OR ${likeness_check}`;
+};
+
+const release_year_search = (year) => {
+  const dashIdx = year.indexOf('-');
+  const isRangeCheck = dashIdx > 0;
+
+  if (isRangeCheck) {
+    const year_low = year.substring(0, dashIdx);
+    const year_high = parseInt(year.substring(dashIdx + 1)) + 1;
+    return `int4range(${year_low}, ${year_high}) @> movies.release_year`;
+  } else {
+    return `release_year = ${year}`;
+  }
+};
+
+exports.search = (query) => {
+  const orderByName = `levenshtein(LOWER(name), LOWER('${query.name}')) ASC`;
+  let searchQuery;
+
+  if (query.name && (query.release_year || query.release_year_range)) {
+    const nameSearch = name_search(query.name, 'year_filtered');
+    const year = query.release_year ? query.release_year.toString() : null;
+    const yearSearch = release_year_search(year || query.release_year_range);
+
+    searchQuery = function (qb) {
+      qb.select('*')
+      .from(function () {
+        this.select('*')
+        .from('movies')
+        .whereRaw(yearSearch)
+        .as('year_filtered');
+      })
+      .whereRaw(nameSearch)
+      .orderByRaw(orderByName);
+    };
+
+  } else if (query.name) {
+    const nameSearch = name_search(query.name, 'movies');
+
+    searchQuery = function (qb) {
+      qb.select('*')
+      .from('movies')
+      .whereRaw(nameSearch)
+      .orderByRaw(orderByName);
+    };
+
+  } else if (query.release_year || query.release_year_range) {
+    const year = query.release_year ? query.release_year.toString() : null;
+    const yearSearch = release_year_search(year || query.release_year_range);
+
+    searchQuery = function (qb) {
+      qb.select('*')
+      .from('movies')
+      .whereRaw(yearSearch)
+      .orderBy('release_year');
+    };
+
+  } else {
+    return new Movie().fetchAll();
+  }
+
+  return new Movie().query(searchQuery).fetchAll();
+
+};

--- a/lib/plugins/features/movies/search.js
+++ b/lib/plugins/features/movies/search.js
@@ -19,13 +19,10 @@ const name_search = (name, table) => {
 };
 
 const release_year_search = (year) => {
-  const dashIdx = year.indexOf('-');
-  const isRangeCheck = dashIdx > 0;
+  const years = year.split('-').sort();
 
-  if (isRangeCheck) {
-    const year_low = year.substring(0, dashIdx);
-    const year_high = parseInt(year.substring(dashIdx + 1)) + 1;
-    return `int4range(${year_low}, ${year_high}) @> movies.release_year`;
+  if (years.length > 1) {
+    return `int4range(${years[0]}, ${parseInt(years[1])+1}) @> movies.release_year`;
   } else {
     return `release_year = ${year}`;
   }
@@ -74,7 +71,7 @@ exports.search = (query) => {
     };
 
   } else {
-    return new Movie().fetchAll();
+    return new Movie(query).fetchAll();
   }
 
   return new Movie().query(searchQuery).fetchAll();

--- a/lib/plugins/features/movies/search.js
+++ b/lib/plugins/features/movies/search.js
@@ -22,7 +22,7 @@ const release_year_search = (year) => {
   const years = year.split('-').sort();
 
   if (years.length > 1) {
-    return `int4range(${years[0]}, ${parseInt(years[1])+1}) @> movies.release_year`;
+    return `int4range(${years[0]}, ${parseInt(years[1]) + 1}) @> movies.release_year`;
   } else {
     return `release_year = ${year}`;
   }

--- a/lib/validators/movie.js
+++ b/lib/validators/movie.js
@@ -10,7 +10,8 @@ const post = Joi.object().keys({
 const get = Joi.object().keys({
   id: Joi.number().integer().min(1).optional(),
   title: Joi.string().min(1).max(255).optional(),
-  release_year: Joi.number().integer().min(1878).max(9999).optional()
+  release_year: Joi.number().integer().min(1878).max(9999).optional(),
+  release_year_range: Joi.string().min(4).max(9).optional()
 });
 
 module.exports = {

--- a/lib/validators/movie.js
+++ b/lib/validators/movie.js
@@ -2,7 +2,16 @@
 
 const Joi = require('joi');
 
-module.exports = Joi.object().keys({
+const post = Joi.object().keys({
   title: Joi.string().min(1).max(255).required(),
   release_year: Joi.number().integer().min(1878).max(9999).optional()
 });
+
+const get = Joi.object().keys({
+  id: Joi.number().integer().min(1).required()
+});
+
+module.exports = {
+  post,
+  get
+};

--- a/lib/validators/movie.js
+++ b/lib/validators/movie.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi');
 
-const post = Joi.object().keys({
+const create = Joi.object().keys({
   title: Joi.string().min(1).max(255).required(),
   release_year: Joi.number().integer().min(1878).max(9999).optional()
 });
@@ -11,10 +11,10 @@ const get = Joi.object().keys({
   id: Joi.number().integer().min(1).optional(),
   title: Joi.string().min(1).max(255).optional(),
   release_year: Joi.number().integer().min(1878).max(9999).optional(),
-  release_year_range: Joi.string().min(4).max(9).optional()
-});
+  release_year_range: Joi.string().regex(/^((187[89])|(18[89]\d)|(19\d\d)|([2-9]\d\d\d))\-((187[89])|(18[89]\d)|(19\d\d)|([2-9]\d\d\d))$/).optional()
+}).or(['title', 'release_year', 'release_year_range', 'id']);
 
 module.exports = {
-  post,
+  create,
   get
 };

--- a/lib/validators/movie.js
+++ b/lib/validators/movie.js
@@ -11,7 +11,18 @@ const get = Joi.object().keys({
   id: Joi.number().integer().min(1).optional(),
   title: Joi.string().min(1).max(255).optional(),
   release_year: Joi.number().integer().min(1878).max(9999).optional(),
-  release_year_range: Joi.string().regex(/^((187[89])|(18[89]\d)|(19\d\d)|([2-9]\d\d\d))\-((187[89])|(18[89]\d)|(19\d\d)|([2-9]\d\d\d))$/).optional()
+  release_year_range:
+    Joi.string().regex(/^((187[89])|(18[89]\d)|(19\d\d)|([2-9]\d\d\d))\-((187[89])|(18[89]\d)|(19\d\d)|([2-9]\d\d\d))$/)
+    .options({
+      language: {
+        string: {
+          regex: {
+            base: 'must be within 1878 and 9999'
+          }
+        }
+      }
+    })
+    .optional()
 }).or(['title', 'release_year', 'release_year_range', 'id']);
 
 module.exports = {

--- a/lib/validators/movie.js
+++ b/lib/validators/movie.js
@@ -8,7 +8,9 @@ const post = Joi.object().keys({
 });
 
 const get = Joi.object().keys({
-  id: Joi.number().integer().min(1).required()
+  id: Joi.number().integer().min(1).optional(),
+  title: Joi.string().min(1).max(255).optional(),
+  release_year: Joi.number().integer().min(1878).max(9999).optional()
 });
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "db:rollback": "knex migrate:rollback --knexfile db/index.js",
     "db:seed": "yarn run db:reset && knex seed:run --knexfile db/index.js",
     "db:setup": "if [ \"$NODE_ENV\" != \"production\" ]; then createdb -O $(node -e \"var c = require('./config'); console.log(c.DB_USER, c.DB_NAME);\"); fi",
-    "db:setup:user": "if [ \"$NODE_ENV\" != \"production\" ]; then createuser $(node -p \"require('./config').DB_USER\"); fi",
+    "db:setup:user": "if [ \"$NODE_ENV\" != \"production\" ]; then createuser -s $(node -p \"require('./config').DB_USER\"); fi",
     "enforce": "istanbul check-coverage --statement 100 --branch 100 --function 100 --lines 100",
     "lint": "eslint .",
     "release:major": "changelog -M && git add CHANGELOG.md && git commit -m 'updated CHANGELOG.md' && npm version major && git push origin && git push origin --tags",

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -49,7 +49,7 @@ describe('movie controller', () => {
       }
     ];
 
-    const fields = ['id', 'name', 'release_year'];
+    const fields = ['id', 'release_year'];
 
     before(() => {
       return Knex.raw('TRUNCATE movies CASCADE')
@@ -69,14 +69,19 @@ describe('movie controller', () => {
       it(`gets a movie by ${field}`, () => {
         return Controller.get({ [field]: sampleMovies[0][field] })
         .then((movies) => {
-          if (field === 'name') {
-            expect(movies.models.length).to.eql(4);
-            expect(movies.models.map((movie) => movie.attributes)).to.eql(sampleMovies.slice(0, 4));
-          } else {
-            expect(movies.models.length).to.eql(1);
-            expect(movies.models[0].attributes).to.eql(sampleMovies[0]);
-          }
+          expect(movies.models.length).to.eql(1);
+          expect(movies.models[0].attributes).to.eql(sampleMovies[0]);
         });
+      });
+    });
+
+    it('gets a movie by name', () => {
+      const expectedOutput = sampleMovies.slice(0, 4);
+
+      return Controller.get({ name: 'Sample Movie' })
+      .then((movies) => {
+        expect(movies.length).to.eql(4);
+        expect(movies.models.map((movie) => movie.attributes)).to.eql(expectedOutput);
       });
     });
 

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -40,23 +40,16 @@ describe('movie controller', () => {
         release_year: 9993
       },
       {
-        name: 'Sa',
+        name: 'Ma',
         release_year: 9994
       },
       {
-        name: 'Samp',
+        name: 'Camp',
         release_year: 9995
       }
     ];
 
     const fields = ['id', 'name', 'release_year'];
-
-    const verify = (movies) => {
-      movies.models.forEach((movie) => {
-        const matched = sampleMovies.find((sample) => sample.id === movie.id);
-        expect(matched).to.eql(movie.attributes);
-      });
-    };
 
     before(() => {
       return Knex.raw('TRUNCATE movies CASCADE')
@@ -74,44 +67,70 @@ describe('movie controller', () => {
 
     fields.forEach((field) => {
       it(`gets a movie by ${field}`, () => {
-        const filter = {};
-
-        return Controller.get(filter[field] = sampleMovies[0][field])
-        .then(verify);
+        return Controller.get({ [field]: sampleMovies[0][field] })
+        .then((movies) => {
+          if (field === 'name') {
+            expect(movies.models.length).to.eql(4);
+            expect(movies.models.map((movie) => movie.attributes)).to.eql(sampleMovies.slice(0, 4));
+          } else {
+            expect(movies.models.length).to.eql(1);
+            expect(movies.models[0].attributes).to.eql(sampleMovies[0]);
+          }
+        });
       });
     });
 
     it('gets a movie by release_year_range', () => {
+      const expectedOutput = sampleMovies.slice(0, 4);
       return Controller.get({ release_year_range: '9990-9993' })
-      .then(verify);
+      .then((movies) => {
+        expect(movies.length).to.eql(4);
+        expect(movies.models.map((movie) => movie.attributes)).to.eql(expectedOutput);
+      });
     });
 
     it('gets a movie by name and release_year', () => {
+      const expectedOutput = sampleMovies[3];
+
       return Controller.get({
         name: sampleMovies[0].name,
         release_year: 9993
       })
-      .then(verify);
+      .then((movie) => {
+        expect(movie.models.length).to.eql(1);
+        expect(movie.models[0].attributes).to.eql(expectedOutput);
+      });
     });
 
     it('gets a movie by name and release_year_range', () => {
+      const expectedOutput = sampleMovies.slice(2, 4);
+
       return Controller.get({
         name: sampleMovies[0].name,
         release_year_range: '9992-9993'
       })
-      .then(verify);
+      .then((movies) => {
+        expect(movies.models.length).to.eql(2);
+        expect(movies.models.map((movie) => movie.attributes)).to.eql(expectedOutput);
+      });
     });
 
     it('gets a movie by fuzzy name', () => {
-      return Controller.get({ name: 'SmpleMovie' })
-      .then(verify);
+      const expectedOutput = sampleMovies[0];
+
+      return Controller.get({ name: 'Smple Movi' })
+      .then((movies) => {
+        expect(movies.models.length).to.eql(1);
+        expect(movies.models[0].attributes).to.eql(expectedOutput);
+      });
     });
 
     it('gets movies by search string length of 2', () => {
       return Controller.get({
-        name: 'Sa'
+        name: 'Ma'
       })
       .then((movies) => {
+        expect(movies.models.length).to.eql(1);
         expect(movies.models[0].attributes).to.eql(sampleMovies[4]);
       });
     });
@@ -127,9 +146,10 @@ describe('movie controller', () => {
 
     it('gets a movie by search string length of 4', () => {
       return Controller.get({
-        name: 'Samp'
+        name: 'Camp'
       })
       .then((movies) => {
+        expect(movies.models.length).to.eql(1);
         expect(movies.models[0].attributes).to.eql(sampleMovies[5]);
       });
     });
@@ -139,6 +159,7 @@ describe('movie controller', () => {
         name: 'Lamp'
       })
       .then((movies) => {
+        expect(movies.models.length).to.eql(1);
         expect(movies.models[0].attributes).to.eql(sampleMovies[5]);
       });
     });

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -3,6 +3,7 @@
 const Controller = require('../../../../lib/plugins/features/movies/controller');
 const Knex       = require('../../../../lib/libraries/knex');
 const Movie      = require('../../../../lib/models/movie');
+const Bluebird   = require('bluebird');
 
 describe('movie controller', () => {
 
@@ -59,7 +60,7 @@ describe('movie controller', () => {
 
     before(() => {
       return Knex.raw('TRUNCATE movies CASCADE')
-      .then(() => Promise.all(sampleMovies.map((movie) => new Movie().save(movie))))
+      .then(() => Bluebird.all(sampleMovies.map((movie) => new Movie().save(movie))))
       .then((movies) => {
         movies.forEach((movie, index) => {
           sampleMovies[index].id = movie.get('id');

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -48,6 +48,15 @@ describe('movie controller', () => {
       }
     ];
 
+    const fields = ['id', 'name', 'release_year'];
+
+    const verify = (movies) => {
+      movies.models.forEach((movie) => {
+        const matched = sampleMovies.find((sample) => sample.id === movie.id);
+        expect(matched).to.eql(movie.attributes);
+      });
+    };
+
     before(() => {
       return Knex.raw('TRUNCATE movies CASCADE')
       .then(() => Promise.all(sampleMovies.map((movie) => new Movie().save(movie))))
@@ -62,42 +71,18 @@ describe('movie controller', () => {
       return new Movie().where('name', 'LIKE', 'Sa%').destroy();
     });
 
-    it('gets a movie by id', () => {
-      return Controller.get({ id: sampleMovies[0].id })
-      .then((movies) => {
-        expect(movies.models[0].get('id')).to.eql(sampleMovies[0].id);
-        expect(movies.models[0].get('release_year')).to.eql(sampleMovies[0].release_year);
-        expect(movies.models[0].get('name')).to.eql(sampleMovies[0].name);
-      });
-    });
+    fields.forEach((field) => {
+      it(`gets a movie by ${field}`, () => {
+        const filter = {};
 
-    it('gets a movie by name', () => {
-      return Controller.get({ name: sampleMovies[0].name })
-      .then((movies) => {
-        movies.models.forEach((movie) => {
-          const matched = sampleMovies.find((sample) => sample.id === movie.id);
-          expect(matched).to.eql(movie.attributes);
-        });
-      });
-    });
-
-    it('gets movies by release_year', () => {
-      return Controller.get({ release_year: 9990 })
-      .then((movies) => {
-        expect(movies.models[0].get('id')).to.eql(sampleMovies[0].id);
-        expect(movies.models[0].get('release_year')).to.eql(sampleMovies[0].release_year);
-        expect(movies.models[0].get('name')).to.eql(sampleMovies[0].name);
+        return Controller.get(filter[field] = sampleMovies[0][field])
+        .then(verify);
       });
     });
 
     it('gets a movie by release_year_range', () => {
       return Controller.get({ release_year_range: '9990-9993' })
-      .then((movies) => {
-        movies.models.forEach((movie) => {
-          const matched = sampleMovies.find((sample) => sample.id === movie.id);
-          expect(matched).to.eql(movie.attributes);
-        });
-      });
+      .then(verify);
     });
 
     it('gets a movie by name and release_year', () => {
@@ -105,11 +90,7 @@ describe('movie controller', () => {
         name: sampleMovies[0].name,
         release_year: 9993
       })
-      .then((movies) => {
-        expect(movies.models[0].get('id')).to.eql(sampleMovies[3].id);
-        expect(movies.models[0].get('release_year')).to.eql(sampleMovies[3].release_year);
-        expect(movies.models[0].get('name')).to.eql(sampleMovies[3].name);
-      });
+      .then(verify);
     });
 
     it('gets a movie by name and release_year_range', () => {
@@ -117,25 +98,12 @@ describe('movie controller', () => {
         name: sampleMovies[0].name,
         release_year_range: '9992-9993'
       })
-      .then((movies) => {
-        console.log('MOVIES', movies.models);
-        expect(movies.models[0].get('id')).to.eql(sampleMovies[2].id);
-        expect(movies.models[0].get('release_year')).to.eql(sampleMovies[2].release_year);
-        expect(movies.models[0].get('name')).to.eql(sampleMovies[2].name);
-        expect(movies.models[1].get('id')).to.eql(sampleMovies[3].id);
-        expect(movies.models[1].get('release_year')).to.eql(sampleMovies[3].release_year);
-        expect(movies.models[1].get('name')).to.eql(sampleMovies[3].name);
-      });
+      .then(verify);
     });
 
     it('gets a movie by fuzzy name', () => {
       return Controller.get({ name: 'SmpleMovie' })
-      .then((movies) => {
-        movies.models.forEach((movie) => {
-          const matched = sampleMovies.find((sample) => sample.id === movie.id);
-          expect(matched).to.eql(movie.attributes);
-        });
-      });
+      .then(verify);
     });
 
     it('gets movies by search string length of 2', () => {

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -61,9 +61,6 @@ describe('movie controller', () => {
 
     after(() => {
       return new Movie().where('name', 'Sample Movie').destroy();
-      // .then((response) => {
-      //   console.log('DESTROY RESPONSE', response);
-      // });
     });
 
   });

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Controller = require('../../../../lib/plugins/features/movies/controller');
+const Movie      = require('../../../../lib/models/movie');
 
 describe('movie controller', () => {
 
@@ -13,6 +14,56 @@ describe('movie controller', () => {
       .then((movie) => {
         expect(movie.get('name')).to.eql(payload.name);
       });
+    });
+
+  });
+
+  describe('get', () => {
+
+    const sampleMovie = {
+      name: 'Sample Movie',
+      release_year: 9999
+    };
+
+    before(() => {
+      return new Movie().save(sampleMovie)
+      .then((movie) => {
+        sampleMovie.id = movie.get('id');
+      });
+    });
+
+    it('gets a movie from id', () => {
+      return Controller.get({ id: sampleMovie.id })
+      .then((movie) => {
+        expect(movie.get('id')).to.eql(sampleMovie.id);
+        expect(movie.get('release_year')).to.eql(sampleMovie.release_year);
+        expect(movie.get('name')).to.eql(sampleMovie.name);
+      });
+    });
+
+    it('gets a movie from name', () => {
+      return Controller.get({ name: sampleMovie.name })
+      .then((movie) => {
+        expect(movie.get('id')).to.eql(sampleMovie.id);
+        expect(movie.get('release_year')).to.eql(sampleMovie.release_year);
+        expect(movie.get('name')).to.eql(sampleMovie.name);
+      });
+    });
+
+    it('gets movies from release_year', () => {
+      return Controller.get({ release_year: sampleMovie.release_year })
+      .then((movie) => {
+        expect(movie.get('id')).to.eql(sampleMovie.id);
+        expect(movie.get('release_year')).to.eql(sampleMovie.release_year);
+        expect(movie.get('name')).to.eql(sampleMovie.name);
+      });
+    });
+
+    after(() => {
+      return new Movie().where('name', 'Sample Movie').destroy();
+      // .then((response) => {
+      //   console.log('DESTROY RESPONSE', response);
+      // });
     });
 
   });

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const Knex   = require('../../../../lib/libraries/knex');
-const Movies = require('../../../../lib/server');
-const Movie  = require('../../../../lib/models/movie');
+const Knex     = require('../../../../lib/libraries/knex');
+const Movies   = require('../../../../lib/server');
+const Movie    = require('../../../../lib/models/movie');
+const Bluebird = require('bluebird');
 
 describe('movies integration', () => {
 
@@ -46,7 +47,7 @@ describe('movies integration', () => {
 
     before(() => {
       return Knex.raw('TRUNCATE movies CASCADE')
-      .then(() => Promise.all(sampleMovies.map((movie) => new Movie().save(movie))))
+      .then(() => Bluebird.all(sampleMovies.map((movie) => new Movie().save(movie))))
       .then((movies) => {
         movies.forEach((movie, index) => {
           sampleMovies[index].id = movie.get('id');

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Movies = require('../../../../lib/server');
+const Movie  = require('../../../../lib/models/movie');
 
 describe('movies integration', () => {
 
@@ -17,6 +18,79 @@ describe('movies integration', () => {
         expect(response.result.object).to.eql('movie');
         expect(response.result.title).to.eql('Volver');
       });
+    });
+
+  });
+
+  describe('get', () => {
+
+    it('gets a list of movies', () => {
+      return Movies.inject({
+        url: '/movies',
+        method: 'GET'
+      }).then((response) => {
+        expect(response.statusCode).to.eql(200);
+        expect(Array.isArray(response.result)).to.eql(true);
+      });
+    });
+
+    let sampleMovie = {
+      title: 'Sample Movie',
+      release_year: 9999
+    };
+
+    before(() => {
+      return Movies.inject({
+        url: '/movies',
+        method: 'POST',
+        payload: sampleMovie
+      }).then((response) => {
+        sampleMovie = response.result;
+      });
+    });
+
+    it('gets a movie with an id', () => {
+      return Movies.inject({
+        url: `/movies?id=${sampleMovie.id}`,
+        method: 'GET'
+      }).then((response) => {
+        expect(response.statusCode).to.eql(200);
+        expect(response.result).to.eql(sampleMovie);
+      });
+    });
+
+    it('gets a movie with a release year', () => {
+      return Movies.inject({
+        url: `/movies?release_year=${sampleMovie.release_year}`,
+        method: 'GET'
+      }).then((response) => {
+        expect(response.statusCode).to.eql(200);
+        expect(response.result).to.eql(sampleMovie);
+      });
+    });
+
+    it('gets a movie with a title', () => {
+      return Movies.inject({
+        url: `/movies?title=${sampleMovie.title}`,
+        method: 'GET'
+      }).then((response) => {
+        expect(response.statusCode).to.eql(200);
+        expect(response.result).to.eql(sampleMovie);
+      });
+    });
+
+    it('gets a movie with a release year and title', () => {
+      return Movies.inject({
+        url: `/movies?title=${sampleMovie.title}&release_year=${sampleMovie.release_year}`,
+        method: 'GET'
+      }).then((response) => {
+        expect(response.statusCode).to.eql(200);
+        expect(response.result).to.eql(sampleMovie);
+      });
+    });
+
+    after(() => {
+      return new Movie().where('name', 'Sample Movie').destroy();
     });
 
   });
@@ -63,6 +137,7 @@ describe('movies integration', () => {
         expect(response.statusCode).to.eql(422);
         expect(response.result.error.message).to.eql('release_year must be larger than or equal to 1878');
       });
+
     });
 
   });

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -94,7 +94,6 @@ describe('movie validator', () => {
 
         expect(result.error.details[0].path).to.eql('release_year');
         expect(result.error.details[0].type).to.eql('number.min');
-
       });
 
       it('is limited to 4 digits', () => {
@@ -121,9 +120,10 @@ describe('movie validator', () => {
 
         expect(result.error.details[0].path).to.eql('release_year_range');
         expect(result.error.details[0].type).to.eql('string.regex.base');
-
       });
 
     });
+
   });
+
 });

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -4,108 +4,126 @@ const Joi = require('joi');
 
 const MovieValidator = require('../../lib/validators/movie');
 
-describe('/POST movie validator', () => {
+describe('movie validator', () => {
 
-  describe('title', () => {
+  describe('post/create', () => {
 
-    it('is required', () => {
-      const payload = {};
-      const result = Joi.validate(payload, MovieValidator.post);
+    describe('title', () => {
 
-      expect(result.error.details[0].path).to.eql('title');
-      expect(result.error.details[0].type).to.eql('any.required');
-    });
+      it('is required', () => {
+        const payload = {};
+        const result = Joi.validate(payload, MovieValidator.create);
 
-    it('is less than 255 characters', () => {
-      const payload = { title: 'a'.repeat(260) };
-      const result = Joi.validate(payload, MovieValidator.post);
+        expect(result.error.details[0].path).to.eql('title');
+        expect(result.error.details[0].type).to.eql('any.required');
+      });
 
-      expect(result.error.details[0].path).to.eql('title');
-      expect(result.error.details[0].type).to.eql('string.max');
-    });
+      it('is less than 255 characters', () => {
+        const payload = { title: 'a'.repeat(260) };
+        const result = Joi.validate(payload, MovieValidator.create);
 
-  });
-
-  describe('release_year', () => {
-
-    it('is after 1878', () => {
-      const payload = {
-        title: 'foo',
-        release_year: 1800
-      };
-      const result = Joi.validate(payload, MovieValidator.post);
-
-      expect(result.error.details[0].path).to.eql('release_year');
-      expect(result.error.details[0].type).to.eql('number.min');
+        expect(result.error.details[0].path).to.eql('title');
+        expect(result.error.details[0].type).to.eql('string.max');
+      });
 
     });
 
-    it('is limited to 4 digits', () => {
-      const payload = {
-        title: 'foo',
-        release_year: 12345
-      };
-      const result = Joi.validate(payload, MovieValidator.post);
+    describe('release_year', () => {
 
-      expect(result.error.details[0].path).to.eql('release_year');
-      expect(result.error.details[0].type).to.eql('number.max');
-    });
+      it('is after 1878', () => {
+        const payload = {
+          title: 'foo',
+          release_year: 1800
+        };
+        const result = Joi.validate(payload, MovieValidator.create);
 
-  });
+        expect(result.error.details[0].path).to.eql('release_year');
+        expect(result.error.details[0].type).to.eql('number.min');
 
-});
+      });
 
-describe('/GET movie validator', () => {
+      it('is limited to 4 digits', () => {
+        const payload = {
+          title: 'foo',
+          release_year: 12345
+        };
+        const result = Joi.validate(payload, MovieValidator.create);
 
-  describe('id', () => {
+        expect(result.error.details[0].path).to.eql('release_year');
+        expect(result.error.details[0].type).to.eql('number.max');
+      });
 
-    it('is greater than 0', () => {
-      const payload = { id: -1 };
-      const result = Joi.validate(payload, MovieValidator.get);
-
-      expect(result.error.details[0].path).to.eql('id');
-      expect(result.error.details[0].type).to.eql('number.min');
     });
 
   });
 
-  describe('title', () => {
+  describe('get', () => {
 
-    it('is less than 255 characters', () => {
-      const payload = { title: 'a'.repeat(260) };
-      const result = Joi.validate(payload, MovieValidator.get);
+    describe('id', () => {
 
-      expect(result.error.details[0].path).to.eql('title');
-      expect(result.error.details[0].type).to.eql('string.max');
+      it('is greater than 0', () => {
+        const payload = { id: -1 };
+        const result = Joi.validate(payload, MovieValidator.get);
+
+        expect(result.error.details[0].path).to.eql('id');
+        expect(result.error.details[0].type).to.eql('number.min');
+      });
+
     });
 
+    describe('title', () => {
+
+      it('is less than 255 characters', () => {
+        const payload = { title: 'a'.repeat(260) };
+        const result = Joi.validate(payload, MovieValidator.get);
+
+        expect(result.error.details[0].path).to.eql('title');
+        expect(result.error.details[0].type).to.eql('string.max');
+      });
+
+    });
+
+    describe('release_year', () => {
+
+      it('is after 1878', () => {
+        const payload = {
+          title: 'foo',
+          release_year: 1800
+        };
+        const result = Joi.validate(payload, MovieValidator.get);
+
+        expect(result.error.details[0].path).to.eql('release_year');
+        expect(result.error.details[0].type).to.eql('number.min');
+
+      });
+
+      it('is limited to 4 digits', () => {
+        const payload = {
+          title: 'foo',
+          release_year: 12345
+        };
+        const result = Joi.validate(payload, MovieValidator.get);
+
+        expect(result.error.details[0].path).to.eql('release_year');
+        expect(result.error.details[0].type).to.eql('number.max');
+      });
+
+    });
+
+    describe('release_year_range', () => {
+
+      it('is after 1878', () => {
+        const payload = {
+          title: 'foo',
+          release_year_range: '1800-1820'
+        };
+        const result = Joi.validate(payload, MovieValidator.get);
+
+        expect(result.error.details[0].path).to.eql('release_year_range');
+        expect(result.error.details[0].type).to.eql('string.regex.base');
+
+      });
+
+    });
   });
-
-  describe('release_year', () => {
-
-    it('is after 1878', () => {
-      const payload = {
-        title: 'foo',
-        release_year: 1800
-      };
-      const result = Joi.validate(payload, MovieValidator.get);
-
-      expect(result.error.details[0].path).to.eql('release_year');
-      expect(result.error.details[0].type).to.eql('number.min');
-
-    });
-
-    it('is limited to 4 digits', () => {
-      const payload = {
-        title: 'foo',
-        release_year: 12345
-      };
-      const result = Joi.validate(payload, MovieValidator.get);
-
-      expect(result.error.details[0].path).to.eql('release_year');
-      expect(result.error.details[0].type).to.eql('number.max');
-    });
-
-  });
-
 });

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -4,13 +4,13 @@ const Joi = require('joi');
 
 const MovieValidator = require('../../lib/validators/movie');
 
-describe('movie validator', () => {
+describe('/POST movie validator', () => {
 
-  describe('name', () => {
+  describe('title', () => {
 
     it('is required', () => {
       const payload = {};
-      const result = Joi.validate(payload, MovieValidator);
+      const result = Joi.validate(payload, MovieValidator.post);
 
       expect(result.error.details[0].path).to.eql('title');
       expect(result.error.details[0].type).to.eql('any.required');
@@ -18,7 +18,7 @@ describe('movie validator', () => {
 
     it('is less than 255 characters', () => {
       const payload = { title: 'a'.repeat(260) };
-      const result = Joi.validate(payload, MovieValidator);
+      const result = Joi.validate(payload, MovieValidator.post);
 
       expect(result.error.details[0].path).to.eql('title');
       expect(result.error.details[0].type).to.eql('string.max');
@@ -33,7 +33,7 @@ describe('movie validator', () => {
         title: 'foo',
         release_year: 1800
       };
-      const result = Joi.validate(payload, MovieValidator);
+      const result = Joi.validate(payload, MovieValidator.post);
 
       expect(result.error.details[0].path).to.eql('release_year');
       expect(result.error.details[0].type).to.eql('number.min');
@@ -45,7 +45,62 @@ describe('movie validator', () => {
         title: 'foo',
         release_year: 12345
       };
-      const result = Joi.validate(payload, MovieValidator);
+      const result = Joi.validate(payload, MovieValidator.post);
+
+      expect(result.error.details[0].path).to.eql('release_year');
+      expect(result.error.details[0].type).to.eql('number.max');
+    });
+
+  });
+
+});
+
+describe('/GET movie validator', () => {
+
+  describe('id', () => {
+
+    it('is greater than 0', () => {
+      const payload = { id: -1 };
+      const result = Joi.validate(payload, MovieValidator.get);
+
+      expect(result.error.details[0].path).to.eql('id');
+      expect(result.error.details[0].type).to.eql('number.min');
+    });
+
+  });
+
+  describe('title', () => {
+
+    it('is less than 255 characters', () => {
+      const payload = { title: 'a'.repeat(260) };
+      const result = Joi.validate(payload, MovieValidator.get);
+
+      expect(result.error.details[0].path).to.eql('title');
+      expect(result.error.details[0].type).to.eql('string.max');
+    });
+
+  });
+
+  describe('release_year', () => {
+
+    it('is after 1878', () => {
+      const payload = {
+        title: 'foo',
+        release_year: 1800
+      };
+      const result = Joi.validate(payload, MovieValidator.get);
+
+      expect(result.error.details[0].path).to.eql('release_year');
+      expect(result.error.details[0].type).to.eql('number.min');
+
+    });
+
+    it('is limited to 4 digits', () => {
+      const payload = {
+        title: 'foo',
+        release_year: 12345
+      };
+      const result = Joi.validate(payload, MovieValidator.get);
 
       expect(result.error.details[0].path).to.eql('release_year');
       expect(result.error.details[0].type).to.eql('number.max');


### PR DESCRIPTION
**What:**
- Adds GET endpoint to server
- Adds fuzzy title and release year range search capability
- Refactors some code to practice DRY
- Adds validation for GET
- Adds unit tests for the server and validator
- Adds integration tests

**Why:**
With users already being able to POST to the server, the server should also allow users to retrieve the data they have posted. Adding /movies GET endpoint enables users to request for movies by title, release year, and/or id

**Details:**
The fuzzy text search utilizes Postgres's fuzzystrmatch extension. In order for this extension to properly execute, one must `CREATE EXTENSION fuzzystrmatch` through psql terminal.

**Context:**
JIRA: [ENG-5937](https://lobsters.atlassian.net/browse/ENG-5937)
Previous PR: Completion of migration of database to rename `title` column to `name`
Next PR: Associating movies with multiple locations